### PR TITLE
ISO C Complience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.6)
 project(untitled)
 
 set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED YES)
+set(CMAKE_C_EXTENSIONS OFF)  # Disable GNU extensions
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wpedantic -Wextra")
 
 set(SOURCE_FILES main.c)
 add_executable(untitled ${SOURCE_FILES})

--- a/main.c
+++ b/main.c
@@ -1,18 +1,18 @@
 #include <stdio.h>
 #include <string.h>
-#include <stdlib.h>
 
 
 //Bubble Sort
 void sort(void * arr, size_t data_size, size_t elem_size, int(*compare)(void * x, void * y)){
+    char* arr_cptr = arr;
     size_t length = data_size/elem_size;
-    for(int i = 0; i<length; i++){
-        for(int j = 0; j<length-1; j++){
-            if(compare(arr + elem_size*j, arr + elem_size * (j+1)) > 0){
+    for(size_t i = 0; i<length; i++){
+        for(size_t j = 0; j<length-1; j++){
+            if(compare(arr_cptr + elem_size*j, arr_cptr + elem_size * (j+1)) > 0){
                 char temp[elem_size];
-                memcpy(temp,arr + elem_size*j,elem_size);
-                memcpy(arr + elem_size*j,arr + elem_size * (j+1), elem_size);
-                memcpy(arr + elem_size * (j+1),temp, elem_size);
+                memcpy(temp,arr_cptr + elem_size*j,elem_size);
+                memcpy(arr_cptr + elem_size*j,arr_cptr + elem_size * (j+1), elem_size);
+                memcpy(arr_cptr + elem_size * (j+1),temp, elem_size);
             };
         }
 
@@ -32,10 +32,10 @@ int compare_char(void * x, void * y){
 }
 
 
-int main() {
+int main(void) {
     int arr[] = {1, 7, 6, 5 , 22, 8, 1, 15, 74};
     sort(arr, sizeof(arr), sizeof(int), compare_int);
-    for(int i =0; i<sizeof(arr)/sizeof(int); i++){
+    for(size_t i =0; i<sizeof(arr)/sizeof(int); i++){
         printf("%d ", arr[i]);
     }
 
@@ -43,7 +43,7 @@ int main() {
 //     char c[] = {'3', '7', '5', '3'};
     char c[] = {'c', 'd', 'b','f','g','a'};
     sort(c, sizeof(c), sizeof(char), compare_char);
-    for(int i = 0; i<sizeof(c)/sizeof(char); i++){
+    for(size_t i = 0; i<sizeof(c)/sizeof(char); i++){
         printf("%c", c[i]);
     }
 


### PR DESCRIPTION
#1

Fixes ISO C Noncomplience:
- Pointer arithmetic is now done with char* instead of void*

Also:
- Replaced K&R main declaration with ANSI/ISO syntax (preferred since C99)
- Fixed comparing int with unsigned long (result of sizeof), `i` is now of type size_t (Although well defined in this case, it is bad practice to compare sign and unsigned integers.)
